### PR TITLE
Addressed review comments:

### DIFF
--- a/apiserver/images.go
+++ b/apiserver/images.go
@@ -142,7 +142,7 @@ func (h *imagesDownloadHandler) fetchAndCacheLxcImage(storage imagestorage.Stora
 	if err != nil {
 		return errors.Trace(err)
 	}
-	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch, cfg.CloudImageBaseURL(), cfg.ImageStream())
+	imageURL, err := container.ImageDownloadURL(instance.LXC, series, arch, cfg.ImageStream(), cfg.CloudImageBaseURL())
 	if err != nil {
 		return errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1004,9 +1004,12 @@ func (a *MachineAgent) updateSupportedContainers(
 			// Explicitly call the non-named constructor so if anyone
 			// adds additional fields, this fails.
 			container.ImageURLGetterConfig{
-				st.Addr(), envUUID.Id(), []byte(agentConfig.CACert()),
-				cfg.CloudImageBaseURL(), cfg.ImageStream(),
-				container.ImageDownloadURL,
+				ServerRoot:        st.Addr(),
+				EnvUUID:           envUUID.Id(),
+				CACert:            []byte(agentConfig.CACert()),
+				CloudimgBaseUrl:   cfg.CloudImageBaseURL(),
+				CloudimgStream:    cfg.ImageStream(),
+				ImageDownloadFunc: container.ImageDownloadURL,
 			})
 	}
 	params := provisioner.ContainerSetupParams{

--- a/container/image.go
+++ b/container/image.go
@@ -33,7 +33,7 @@ type ImageURLGetterConfig struct {
 	CACert            []byte
 	CloudimgBaseUrl   string
 	CloudimgStream    string
-	ImageDownloadFunc func(kind instance.ContainerType, series, arch, cloudimgBaseUrl, cloudimgStream string) (string, error)
+	ImageDownloadFunc func(kind instance.ContainerType, series, arch, cloudimgStream, cloudimgBaseUrl string) (string, error)
 }
 
 type imageURLGetter struct {
@@ -48,7 +48,7 @@ func NewImageURLGetter(config ImageURLGetterConfig) ImageURLGetter {
 
 // ImageURL is specified on the NewImageURLGetter interface.
 func (ug *imageURLGetter) ImageURL(kind instance.ContainerType, series, arch string) (string, error) {
-	imageURL, err := ug.config.ImageDownloadFunc(kind, series, arch, ug.config.CloudimgBaseUrl, ug.config.CloudimgStream)
+	imageURL, err := ug.config.ImageDownloadFunc(kind, series, arch, ug.config.CloudimgStream, ug.config.CloudimgBaseUrl)
 	if err != nil {
 		return "", errors.Annotatef(err, "cannot determine LXC image URL: %v", err)
 	}
@@ -67,7 +67,7 @@ func (ug *imageURLGetter) CACert() []byte {
 
 // ImageDownloadURL determines the public URL which can be used to obtain an
 // image blob with the specified parameters.
-func ImageDownloadURL(kind instance.ContainerType, series, arch, cloudimgBaseUrl, cloudimgStream string) (string, error) {
+func ImageDownloadURL(kind instance.ContainerType, series, arch, cloudimgStream, cloudimgBaseUrl string) (string, error) {
 	// TODO - we currently only need to support LXC images - kind is ignored.
 	if kind != instance.LXC {
 		return "", errors.Errorf("unsupported container type: %v", kind)

--- a/container/image_test.go
+++ b/container/image_test.go
@@ -28,8 +28,12 @@ func (s *imageURLSuite) SetUpTest(c *gc.C) {
 func (s *imageURLSuite) TestImageURL(c *gc.C) {
 	imageURLGetter := container.NewImageURLGetter(
 		container.ImageURLGetterConfig{
-			"host:port", "12345", []byte("cert"), "",
-			container.ImageDownloadURL,
+			ServerRoot:        "host:port",
+			EnvUUID:           "12345",
+			CACert:            []byte("cert"),
+			CloudimgBaseUrl:   "",
+			CloudimgStream:    "released",
+			ImageDownloadFunc: container.ImageDownloadURL,
 		})
 	imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
@@ -40,13 +44,18 @@ func (s *imageURLSuite) TestImageURL(c *gc.C) {
 func (s *imageURLSuite) TestImageURLOtherBase(c *gc.C) {
 	var calledBaseURL string
 	baseURL := "other://cloud-images"
-	mockFunc := func(kind instance.ContainerType, series, arch, cloudimgBaseUrl string) (string, error) {
+	mockFunc := func(kind instance.ContainerType, series, arch, stream, cloudimgBaseUrl string) (string, error) {
 		calledBaseURL = cloudimgBaseUrl
 		return "omg://wat/trusty-released-amd64-root.tar.gz", nil
 	}
 	imageURLGetter := container.NewImageURLGetter(
 		container.ImageURLGetterConfig{
-			"host:port", "12345", []byte("cert"), baseURL, mockFunc,
+			ServerRoot:        "host:port",
+			EnvUUID:           "12345",
+			CACert:            []byte("cert"),
+			CloudimgBaseUrl:   baseURL,
+			CloudimgStream:    "released",
+			ImageDownloadFunc: mockFunc,
 		})
 	imageURL, err := imageURLGetter.ImageURL(instance.LXC, "trusty", "amd64")
 	c.Assert(err, gc.IsNil)
@@ -56,18 +65,18 @@ func (s *imageURLSuite) TestImageURLOtherBase(c *gc.C) {
 }
 
 func (s *imageURLSuite) TestImageDownloadURL(c *gc.C) {
-	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "")
+	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "released", "")
 	c.Assert(err, gc.IsNil)
 	c.Assert(imageDownloadURL, gc.Equals, "test://cloud-images/trusty-released-amd64-root.tar.gz")
 }
 
 func (s *imageURLSuite) TestImageDownloadURLOtherBase(c *gc.C) {
-	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "other://cloud-images")
+	imageDownloadURL, err := container.ImageDownloadURL(instance.LXC, "trusty", "amd64", "released", "other://cloud-images")
 	c.Assert(err, gc.IsNil)
 	c.Assert(imageDownloadURL, gc.Equals, "other://cloud-images/trusty-released-amd64-root.tar.gz")
 }
 
 func (s *imageURLSuite) TestImageDownloadURLUnsupportedContainer(c *gc.C) {
-	_, err := container.ImageDownloadURL(instance.KVM, "trusty", "amd64", "")
+	_, err := container.ImageDownloadURL(instance.KVM, "trusty", "amd64", "released", "")
 	c.Assert(err, gc.ErrorMatches, "unsupported container .*")
 }

--- a/provider/local/environ.go
+++ b/provider/local/environ.go
@@ -269,15 +269,16 @@ func (env *localEnviron) SetConfig(cfg *config.Config) error {
 			if cert, ok := cfg.CACert(); ok {
 				caCert = []byte(cert)
 			}
-			baseUrl := ecfg.CloudImageBaseURL()
-			stream := ecfg.ImageStream()
-
 			imageURLGetter = container.NewImageURLGetter(
 				// Explicitly call the non-named constructor so if anyone
 				// adds additional fields, this fails.
 				container.ImageURLGetterConfig{
-					ecfg.stateServerAddr(), uuid, caCert, baseUrl,
-					stream, container.ImageDownloadURL,
+					ServerRoot:        ecfg.stateServerAddr(),
+					EnvUUID:           uuid,
+					CACert:            caCert,
+					CloudimgBaseUrl:   ecfg.CloudImageBaseURL(),
+					CloudimgStream:    ecfg.ImageStream(),
+					ImageDownloadFunc: container.ImageDownloadURL,
 				})
 
 		}


### PR DESCRIPTION
Fixed tests.
Moved stream to follow arch.
Named properties for construction.

We would like to see this in 1.25. 
Please merge it in with your change "Pass ImageStream to ubuntu-cloudimage-query command." and update the Pull Request \o/
https://github.com/juju/juju/pull/4480
